### PR TITLE
Add tutorial test CI with badge

### DIFF
--- a/.github/workflows/tutorial-tests.yml
+++ b/.github/workflows/tutorial-tests.yml
@@ -1,0 +1,26 @@
+name: tutorial-tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.2'
+      - name: Install devtools
+        run: |
+          Rscript -e 'install.packages("devtools", repos="https://cloud.r-project.org")'
+      - name: Install causalimages package
+        run: R CMD INSTALL causalimages
+      - name: Link repository for tests
+        run: |
+          mkdir -p "$HOME/Documents"
+          ln -s "$GITHUB_WORKSPACE" "$HOME/Documents/causalimages-software"
+      - name: Run tutorial tests
+        run: Rscript tests/Test_AAARunAllTutorialsSuite.R

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # `causalimages`: An R Package for Causal Inference with Earth Observation, Bio-medical, and Social Science Images
+[![Tutorial Tests](https://github.com/cjerzak/causalimages-software/actions/workflows/tutorial-tests.yml/badge.svg)](https://github.com/cjerzak/causalimages-software/actions/workflows/tutorial-tests.yml)
 
 [**What is `causalimages`?**](#description)
 | [**Installation**](#installation)


### PR DESCRIPTION
## Summary
- run tutorial test suite via GitHub Actions
- show workflow status badge in `README`

## Testing
- `Rscript tests/Test_AAARunAllTutorialsSuite.R` *(fails: Failed at TfRecordsTest)*

------
https://chatgpt.com/codex/tasks/task_e_68443d828628832f8c71aa0c22802c39