### PR TITLE
Fix CI to build Python backend

### DIFF
--- a/.github/workflows/tutorial-tests.yml
+++ b/.github/workflows/tutorial-tests.yml
@@ -10,14 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.10
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: '4.2'
       - name: Install devtools
         run: |
           Rscript -e 'install.packages("devtools", repos="https://cloud.r-project.org")'
+      - name: Install package dependencies
+        run: |
+          Rscript -e 'devtools::install_deps(dependencies = TRUE)'
       - name: Install causalimages package
         run: R CMD INSTALL causalimages
+      - name: Build backend
+        run: Rscript -e 'causalimages::BuildBackend()'
       - name: Link repository for tests
         run: |
           mkdir -p "$HOME/Documents"


### PR DESCRIPTION
## Summary
- install Miniconda and R deps in the workflow
- call `causalimages::BuildBackend()` so tests have a Python env

## Testing
- `Rscript causalimages/tests/Test_UsingTfRecords.R` *(fails: Unable to find conda binary)*

------
https://chatgpt.com/codex/tasks/task_e_685c03a0b834832fa408787287faa5a1